### PR TITLE
fix __call() override

### DIFF
--- a/src/Bican/Roles/HasRole.php
+++ b/src/Bican/Roles/HasRole.php
@@ -197,7 +197,14 @@ trait HasRole {
             return false;
         }
 
-        throw new BadMethodCallException('Method [' . $method . '] does not exist.');
+        if (in_array($method, array('increment', 'decrement')))
+        {
+            return call_user_func_array(array($this, $method), $parameters);
+        }
+
+        $query = $this->newQuery();
+
+        return call_user_func_array(array($query, $method), $parameters);
     }
 
 }


### PR DESCRIPTION
The `__call` function in `src/Bican/Roles/HasRole.php` causes issues with Laravel's `where()` and possibly other methods.

For example:

```
User::where('role_id', '=', 1);
```
Gives me:
```
BadMethodCallException in HasRole.php line 200:
Method [where] does not exist.
```

I believe it's because you are overriding the `__call` function in `Illuminate\Database\Eloquent\Model`. So I've pulled code out of `Model` and put it in `HasRole` so it will still work. This is probably not the best way to fix the issue but it works for now.