### PR TITLE
Make vendor migrations publishable via Artisan

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@ Pull this package in through Composer.
 
     $ composer update
 
-Copy migrations from `src/migrations` directory.
+Add the package to your application service providers in `app/config/app.php`
+```
+'Bican\Roles\RolesServiceProvider'
+```
 
-    $ php artisan migrate
+Publish the package migrations to your application.
+
+    $ php artisan vendor:publish
 
 ## Usage
 

--- a/src/Bican/Roles/RolesServiceProvider.php
+++ b/src/Bican/Roles/RolesServiceProvider.php
@@ -1,0 +1,28 @@
+<?php namespace Bican\Roles;
+
+use Illuminate\Support\ServiceProvider;
+
+class RolesServiceProvider extends ServiceProvider {
+
+	/**
+	 * Bootstrap any application services.
+	 *
+	 * @return void
+	 */
+	public function boot()
+	{
+		$this->publishes([
+			__DIR__.'/../../migrations/' => base_path('/database/migrations')
+		], 'migrations');
+	}
+
+	/**
+	 * Register any application services.
+	 *
+	 * @return void
+	 */
+	public function register()
+	{
+
+	}
+}


### PR DESCRIPTION
Manually copying migration files is inconvenient. We can automate it with Artisan's `vendor:publish` command.