### PR TITLE
Add users relationship to Role

### DIFF
--- a/src/Bican/Roles/Role.php
+++ b/src/Bican/Roles/Role.php
@@ -1,8 +1,11 @@
 <?php namespace Bican\Roles;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Console\AppNamespaceDetectorTrait;
 
 class Role extends Model {
+
+    use AppNamespaceDetectorTrait;
 
     /**
      * The attributes that are mass assignable.
@@ -19,6 +22,16 @@ class Role extends Model {
     public function permissions()
     {
         return $this->belongsToMany('Bican\Roles\Permission');
+    }
+
+    /**
+     * Role belongs to many users.
+     *
+     * @return mixed
+     */
+    public function users()
+    {
+        return $this->belongsToMany($this->getAppNamespace().'User');
     }
 
     /**


### PR DESCRIPTION
Sorry, I'm working on a project right now and keep running into things I need from your package!

Anyways, this change makes it so you can get all the users associated with a `Role` by doing something like:
```
Role::find($id)->users
```

It also works with custom namespaces by using `AppNamespaceDetectorTrait`.

This is something that obviously is tightly integrated with Laravel's default `User` class, but I don't see a problem with it because your package is already enforcing using `User` in the default migrations.