### PR TITLE
Update 2015_01_15_114412_create_role_user_table.php

### DIFF
--- a/src/migrations/2015_01_15_114412_create_role_user_table.php
+++ b/src/migrations/2015_01_15_114412_create_role_user_table.php
@@ -19,7 +19,6 @@ class CreateRoleUserTable extends Migration {
 			$table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
 			$table->integer('user_id')->unsigned()->index();
 			$table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
-			$table->timestamps();
 		});
 	}
 


### PR DESCRIPTION
removed timestamps on role_user connections
timestamps don't get updated by laravel if you use attach() anyway, so there is no need for two empty timestamp columns