### PR TITLE
add nullable to migrations

### DIFF
--- a/src/migrations/2015_01_15_105324_create_roles_table.php
+++ b/src/migrations/2015_01_15_105324_create_roles_table.php
@@ -17,7 +17,7 @@ class CreateRolesTable extends Migration {
 			$table->increments('id');
 			$table->string('name');
 			$table->string('slug')->unique();
-			$table->string('description');
+			$table->string('description')->nullable();
 			$table->integer('level')->default(1);
 			$table->timestamps();
 		});

--- a/src/migrations/2015_01_26_115212_create_permissions_table.php
+++ b/src/migrations/2015_01_26_115212_create_permissions_table.php
@@ -17,8 +17,8 @@ class CreatePermissionsTable extends Migration {
 			$table->increments('id');
 			$table->string('name');
 			$table->string('slug');
-			$table->string('description');
-			$table->string('model');
+			$table->string('description')->nullable();
+			$table->string('model')->nullable();
 			$table->timestamps();
 		});
 	}


### PR DESCRIPTION
This allows optional columns to be set to null in Postgres.