### PR TITLE
needed for Laravel 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~5.0"
+        "illuminate/support": "~5.0|5.1.x"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
I am not sure about the change - but in other packages, such as `barryvdh/laravel-httpcache` it was needed just to install the L5.1