### PR TITLE
make prefix selection automatic

### DIFF
--- a/src/Bican/Roles/Traits/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Traits/HasRoleAndPermission.php
@@ -148,11 +148,13 @@ trait HasRoleAndPermission
     public function rolePermissions()
     {
         if (!$roles = $this->getRoles()->lists('id')->toArray()) { $roles = []; }
+        
+        $prefix = config('database.connections.' . config('database.default') . '.prefix');
 
-        return Permission::select([config('roles.prefix') . 'permissions.*', config('roles.prefix') . 'permission_role.created_at as pivot_created_at', config('roles.prefix') . 'permission_role.updated_at as pivot_updated_at'])
-                ->join(config('roles.prefix') . 'permission_role', config('roles.prefix') . 'permission_role.permission_id', '=', config('roles.prefix') . 'permissions.id')->join(config('roles.prefix') . 'roles', config('roles.prefix') . 'roles.id', '=', config('roles.prefix') . 'permission_role.role_id')
-                ->whereIn(config('roles.prefix') . 'roles.id', $roles) ->orWhere(config('roles.prefix') . 'roles.level', '<', $this->level())
-                ->groupBy(config('roles.prefix') . 'permissions.id');
+        return Permission::select([$prefix . 'permissions.*', $prefix . 'permission_role.created_at as pivot_created_at', $prefix . 'permission_role.updated_at as pivot_updated_at'])
+                ->join($prefix . 'permission_role', $prefix . 'permission_role.permission_id', '=', $prefix . 'permissions.id')->join($prefix . 'roles', $prefix . 'roles.id', '=', $prefix . 'permission_role.role_id')
+                ->whereIn($prefix . 'roles.id', $roles) ->orWhere($prefix . 'roles.level', '<', $this->level())
+                ->groupBy($prefix . 'permissions.id');
     }
 
     /**

--- a/src/config/roles.php
+++ b/src/config/roles.php
@@ -17,18 +17,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Database Table Prefix
-    |--------------------------------------------------------------------------
-    |
-    | By default, this pulls the prefix from your selected database connection.
-    | There is no reason to change this.
-    |
-    */
-
-    'prefix' => config('database.connections.' . config('database.default') . '.prefix'),
-
-    /*
-    |--------------------------------------------------------------------------
     | Slug Separator
     |--------------------------------------------------------------------------
     |

--- a/src/config/roles.php
+++ b/src/config/roles.php
@@ -20,11 +20,12 @@ return [
     | Database Table Prefix
     |--------------------------------------------------------------------------
     |
-    | If your tables have a prefix you may specify that here.
+    | By default, this pulls the prefix from your selected database connection.
+    | There is no reason to change this.
     |
     */
 
-    'prefix' => '',
+    'prefix' => config('database.connections.' . config('database.default') . '.prefix'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
make prefix selection automatic - based on what the users Laravel settings are. No need to define it twice (once in `config\database.php` and once here).