### PR TITLE
Fixed inconsitant database types and indexing

### DIFF
--- a/src/migrations/2015_01_15_105324_create_roles_table.php
+++ b/src/migrations/2015_01_15_105324_create_roles_table.php
@@ -13,7 +13,7 @@ class CreateRolesTable extends Migration
     public function up()
     {
         Schema::create('roles', function (Blueprint $table) {
-            $table->increments('id');
+            $table->increments('id')->unsigned();
             $table->string('name');
             $table->string('slug')->unique();
             $table->string('description')->nullable();

--- a/src/migrations/2015_01_15_114412_create_role_user_table.php
+++ b/src/migrations/2015_01_15_114412_create_role_user_table.php
@@ -13,7 +13,7 @@ class CreateRoleUserTable extends Migration
     public function up()
     {
         Schema::create('role_user', function (Blueprint $table) {
-            $table->increments('id');
+            $table->increments('id')->unsigned();
             $table->integer('role_id')->unsigned()->index();
             $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
             $table->integer('user_id')->unsigned()->index();

--- a/src/migrations/2015_01_26_115212_create_permissions_table.php
+++ b/src/migrations/2015_01_26_115212_create_permissions_table.php
@@ -13,9 +13,9 @@ class CreatePermissionsTable extends Migration
     public function up()
     {
         Schema::create('permissions', function (Blueprint $table) {
-            $table->increments('id');
+            $table->increments('id')->unsigned();
             $table->string('name');
-            $table->string('slug');
+            $table->string('slug')->unique();
             $table->string('description')->nullable();
             $table->string('model')->nullable();
             $table->timestamps();

--- a/src/migrations/2015_01_26_115523_create_permission_role_table.php
+++ b/src/migrations/2015_01_26_115523_create_permission_role_table.php
@@ -13,7 +13,7 @@ class CreatePermissionRoleTable extends Migration
     public function up()
     {
         Schema::create('permission_role', function (Blueprint $table) {
-            $table->increments('id');
+            $table->increments('id')->unsigned();
             $table->integer('permission_id')->unsigned()->index();
             $table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
             $table->integer('role_id')->unsigned()->index();

--- a/src/migrations/2015_02_09_132439_create_permission_user_table.php
+++ b/src/migrations/2015_02_09_132439_create_permission_user_table.php
@@ -13,7 +13,7 @@ class CreatePermissionUserTable extends Migration
     public function up()
     {
         Schema::create('permission_user', function (Blueprint $table) {
-            $table->increments('id');
+            $table->increments('id')->unsigned();
             $table->integer('permission_id')->unsigned()->index();
             $table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
             $table->integer('user_id')->unsigned()->index();


### PR DESCRIPTION
Some primary and foreign keys were signed and others unsigned. I made them all unsigned to make them consistent. Also made all the slugs unique since some were and others were not.