### PR TITLE
Fixed bug where an empty collection would get cached for this->roles

### DIFF
--- a/src/Bican/Roles/Traits/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Traits/HasRoleAndPermission.php
@@ -39,7 +39,9 @@ trait HasRoleAndPermission
      */
     public function getRoles()
     {
-        return (!$this->roles) ? $this->roles = $this->roles()->get() : $this->roles;
+        if(!$this->roles || $this->roles->isEmpty())
+            $this->roles = $this->roles()->get();
+        return $this->roles;
     }
 
     /**


### PR DESCRIPTION
It seems that an empty collection gets cached for $this->roles and the check doesn't replace it.

Here is the unit test that catches it. I suspect that it happens when a role is attached. This pull request makes the unit test pass.

The unit test:
```
<?php

use App\User\Role;
use App\User\Permission;
use App\User\User;
use Illuminate\Foundation\Testing\WithoutMiddleware;
use Illuminate\Foundation\Testing\DatabaseMigrations;
use Illuminate\Foundation\Testing\DatabaseTransactions;

class RoleTest extends TestCase
{
    use DatabaseMigrations;

    public function testAttachRole() {
        $adminRole = $nonAdminUser = factory(Role::class)
            ->create(['slug' => 'admin', 'level' => 1000]);

        $adminUser = factory(User::class)
            ->create(['email' => 'admin@example.com']);
        $adminUser->attachRole($adminRole);

        $this->assertTrue($adminUser->isAdmin());
    }
}
```