### PR TITLE
Made [is,can][All,One] methods public

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,18 +150,30 @@ You can also do this:
 
 ```php
 if ($user->isAdmin()) {
-    //
+    // or alternatively: $user->hasRole('admin')
 }
 ```
 
 And of course, there is a way to check for multiple roles:
 
 ```php
-if ($user->is('admin|moderator')) { // or $user->is('admin, moderator') and also $user->is(['admin', 'moderator'])
+if ($user->is('admin|moderator')) { 
+    // or alternatively: 
+    //   $user->is('admin, moderator')
+    //   $user->is(['admin', 'moderator'])
+    //   $user->isOne('admin|moderator')
+    //   $user->isOne('admin, moderator')
+    //   $user->isOne(['admin', 'moderator'])
     // if user has at least one role
 }
 
-if ($user->is('admin|moderator', true)) { // or $user->is('admin, moderator', true) and also $user->is(['admin', 'moderator'], true)
+if ($user->is('admin|moderator', true)) {
+    // or alternatively: 
+    //   $user->is('admin, moderator', true)
+    //   $user->is(['admin', 'moderator'], true)
+    //   $user->isAll('admin|moderator')
+    //   $user->isAll('admin, moderator')
+    //   $user->isAll(['admin', 'moderator'])
     // if user has all roles
 }
 ```

--- a/src/Bican/Roles/Contracts/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Contracts/HasRoleAndPermission.php
@@ -30,6 +30,30 @@ interface HasRoleAndPermission
     public function is($role, $all = false);
 
     /**
+     * Check if the user has all roles.
+     *
+     * @param int|string|array $role
+     * @return bool
+     */
+    public function isAll($role);
+
+    /**
+     * Check if the user has at least one role.
+     *
+     * @param int|string|array $role
+     * @return bool
+     */
+    public function isOne($role);
+
+    /**
+     * Check if the user has role.
+     *
+     * @param int|string $role
+     * @return bool
+     */
+    public function hasRole($role);
+
+    /**
      * Attach role to a user.
      *
      * @param int|\Bican\Roles\Models\Role $role
@@ -88,6 +112,22 @@ interface HasRoleAndPermission
      * @return bool
      */
     public function can($permission, $all = false);
+
+    /**
+     * Check if the user has all permissions.
+     *
+     * @param int|string|array $permission
+     * @return bool
+     */
+    public function canAll($permission);
+
+    /**
+     * Check if the user has at least one permission.
+     *
+     * @param int|string|array $permission
+     * @return bool
+     */
+    public function canOne($permission);
 
     /**
      * Check if the user is allowed to manipulate with entity.

--- a/src/Bican/Roles/Contracts/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Contracts/HasRoleAndPermission.php
@@ -130,6 +130,14 @@ interface HasRoleAndPermission
     public function canOne($permission);
 
     /**
+     * Check if the user has a permission.
+     *
+     * @param int|string $permission
+     * @return bool
+     */
+    public function hasPermission($permission);
+
+    /**
      * Check if the user is allowed to manipulate with entity.
      *
      * @param string $providedPermission

--- a/src/Bican/Roles/Traits/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Traits/HasRoleAndPermission.php
@@ -55,17 +55,18 @@ trait HasRoleAndPermission
             return $this->pretend('is');
         }
 
-        return $this->{$this->getMethodName('is', $all)}($this->getArrayFrom($role));
+        return $this->{$this->getMethodName('is', $all)}($role);
     }
 
     /**
      * Check if the user has at least one role.
      *
-     * @param array $roles
+     * @param int|string|array $role
      * @return bool
      */
-    protected function isOne(array $roles)
+    public function isOne($role)
     {
+        $roles = $this->getArrayFrom($role);
         foreach ($roles as $role) {
             if ($this->hasRole($role)) {
                 return true;
@@ -78,11 +79,12 @@ trait HasRoleAndPermission
     /**
      * Check if the user has all roles.
      *
-     * @param array $roles
+     * @param int|string|array $role
      * @return bool
      */
-    protected function isAll(array $roles)
+    public function isAll($role)
     {
+        $roles = $this->getArrayFrom($role);
         foreach ($roles as $role) {
             if (!$this->hasRole($role)) {
                 return false;
@@ -98,7 +100,7 @@ trait HasRoleAndPermission
      * @param int|string $role
      * @return bool
      */
-    protected function hasRole($role)
+    public function hasRole($role)
     {
         return $this->getRoles()->contains(function ($key, $value) use ($role) {
             return $role == $value->id || Str::is($role, $value->slug);
@@ -201,17 +203,18 @@ trait HasRoleAndPermission
             return $this->pretend('can');
         }
 
-        return $this->{$this->getMethodName('can', $all)}($this->getArrayFrom($permission));
+        return $this->{$this->getMethodName('can', $all)}($permission);
     }
 
     /**
      * Check if the user has at least one permission.
      *
-     * @param array $permissions
+     * @param int|string|array $permission
      * @return bool
      */
-    protected function canOne(array $permissions)
+    public function canOne($permission)
     {
+        $permissions = $this->getArrayFrom($permission);
         foreach ($permissions as $permission) {
             if ($this->hasPermission($permission)) {
                 return true;
@@ -224,11 +227,12 @@ trait HasRoleAndPermission
     /**
      * Check if the user has all permissions.
      *
-     * @param array $permissions
+     * @param int|string|array $permission
      * @return bool
      */
-    protected function canAll(array $permissions)
+    public function canAll($permission)
     {
+        $permissions = $this->getArrayFrom($permission);
         foreach ($permissions as $permission) {
             if (!$this->hasPermission($permission)) {
                 return false;
@@ -244,7 +248,7 @@ trait HasRoleAndPermission
      * @param int|string $permission
      * @return bool
      */
-    protected function hasPermission($permission)
+    public function hasPermission($permission)
     {
         return $this->getPermissions()->contains(function ($key, $value) use ($permission) {
             return $permission == $value->id || Str::is($permission, $value->slug);

--- a/src/Bican/Roles/Traits/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Traits/HasRoleAndPermission.php
@@ -66,8 +66,7 @@ trait HasRoleAndPermission
      */
     public function isOne($role)
     {
-        $roles = $this->getArrayFrom($role);
-        foreach ($roles as $role) {
+        foreach ($this->getArrayFrom($role) as $role) {
             if ($this->hasRole($role)) {
                 return true;
             }
@@ -84,8 +83,7 @@ trait HasRoleAndPermission
      */
     public function isAll($role)
     {
-        $roles = $this->getArrayFrom($role);
-        foreach ($roles as $role) {
+        foreach ($this->getArrayFrom($role) as $role) {
             if (!$this->hasRole($role)) {
                 return false;
             }
@@ -214,8 +212,7 @@ trait HasRoleAndPermission
      */
     public function canOne($permission)
     {
-        $permissions = $this->getArrayFrom($permission);
-        foreach ($permissions as $permission) {
+        foreach ($this->getArrayFrom($permission) as $permission) {
             if ($this->hasPermission($permission)) {
                 return true;
             }
@@ -232,8 +229,7 @@ trait HasRoleAndPermission
      */
     public function canAll($permission)
     {
-        $permissions = $this->getArrayFrom($permission);
-        foreach ($permissions as $permission) {
+        foreach ($this->getArrayFrom($permission) as $permission) {
             if (!$this->hasPermission($permission)) {
                 return false;
             }


### PR DESCRIPTION
Updated the parameters passed to isOne(), isAll(), canOne() and canAll() to match is() and can() function parameters and made them public since it makes the intention of code more clear than passing a boolean parameter to is() or can().