### PR TITLE
Fixed a bug where the cached copy of relations would get out of sync

### DIFF
--- a/src/Bican/Roles/Contracts/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Contracts/HasRoleAndPermission.php
@@ -33,7 +33,6 @@ interface HasRoleAndPermission
      * Attach role to a user.
      *
      * @param int|\Bican\Roles\Models\Role $role
-     * @return null|bool
      */
     public function attachRole($role);
 
@@ -112,7 +111,6 @@ interface HasRoleAndPermission
      * Detach permission from a user.
      *
      * @param int|\Bican\Roles\Models\Permission $permission
-     * @return int
      */
     public function detachPermission($permission);
 

--- a/src/Bican/Roles/Traits/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Traits/HasRoleAndPermission.php
@@ -16,13 +16,6 @@ trait HasRoleAndPermission
     protected $rolesLoaded = false;
 
     /**
-     * Property for caching permissions.
-     *
-     * @var bool
-     */
-    protected $permissionsLoaded = false;
-
-    /**
      * User belongs to many roles.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
@@ -191,11 +184,7 @@ trait HasRoleAndPermission
      */
     public function getPermissions()
     {
-        if (!$this->permissionsLoaded) {
-            $this->load('permissions');
-            $this->permissionsLoaded = true;
-        }
-        return $this->permissions;
+        return $this->rolePermissions()->get()->merge($this->userPermissions()->get());
     }
 
     /**
@@ -310,8 +299,7 @@ trait HasRoleAndPermission
      */
     public function attachPermission($permission)
     {
-        $this->permissionsLoaded = false;
-        $this->permissions()->attach($permission);
+        $this->userPermissions()->attach($permission);
     }
 
     /**
@@ -322,8 +310,7 @@ trait HasRoleAndPermission
      */
     public function detachPermission($permission)
     {
-        $this->permissionsLoaded = false;
-        $this->permissions()->detach($permission);
+        return $this->userPermissions()->detach($permission);
     }
 
     /**
@@ -333,8 +320,7 @@ trait HasRoleAndPermission
      */
     public function detachAllPermissions()
     {
-        $this->permissionsLoaded = false;
-        $this->permissions()->detach();
+        return $this->userPermissions()->detach();
     }
 
     /**

--- a/src/Bican/Roles/Traits/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Traits/HasRoleAndPermission.php
@@ -11,16 +11,16 @@ trait HasRoleAndPermission
     /**
      * Property for caching roles.
      *
-     * @var \Illuminate\Database\Eloquent\Collection|null
+     * @var bool
      */
-    protected $roles;
+    protected $rolesLoaded = false;
 
     /**
      * Property for caching permissions.
      *
-     * @var \Illuminate\Database\Eloquent\Collection|null
+     * @var bool
      */
-    protected $permissions;
+    protected $permissionsLoaded = false;
 
     /**
      * User belongs to many roles.
@@ -33,13 +33,17 @@ trait HasRoleAndPermission
     }
 
     /**
-     * Get all roles as collection.
+     * Get all roles as collection. Lazy Eagerload roles and flag them as loaded.
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getRoles()
     {
-        return (!$this->roles) ? $this->roles = $this->roles()->get() : $this->roles;
+        if (!$this->rolesLoaded) {
+            $this->load('roles');
+            $this->rolesLoaded = true;
+        }
+        return $this->roles;
     }
 
     /**
@@ -179,13 +183,17 @@ trait HasRoleAndPermission
     }
 
     /**
-     * Get all permissions as collection.
+     * Get all permissions as collection. Lazy Eagerload roles and flag them as loaded.
      *
      * @return \Illuminate\Database\Eloquent\Collection
      */
     public function getPermissions()
     {
-        return (!$this->permissions) ? $this->permissions = $this->rolePermissions()->get()->merge($this->userPermissions()->get()) : $this->permissions;
+        if (!$this->permissionsLoaded) {
+            $this->load('permissions');
+            $this->permissionsLoaded = true;
+        }
+        return $this->permissions;
     }
 
     /**

--- a/src/Bican/Roles/Traits/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Traits/HasRoleAndPermission.php
@@ -113,11 +113,11 @@ trait HasRoleAndPermission
      * Attach role to a user.
      *
      * @param int|\Bican\Roles\Models\Role $role
-     * @return null|bool
      */
     public function attachRole($role)
     {
-        return (!$this->getRoles()->contains($role)) ? $this->roles()->attach($role) : true;
+        $this->rolesLoaded = false;
+        $this->roles()->attach($role);
     }
 
     /**
@@ -128,7 +128,8 @@ trait HasRoleAndPermission
      */
     public function detachRole($role)
     {
-        return $this->roles()->detach($role);
+        $this->rolesLoaded = false;
+        return $this->roles()->deattach($role);
     }
 
     /**
@@ -138,6 +139,7 @@ trait HasRoleAndPermission
      */
     public function detachAllRoles()
     {
+        $this->rolesLoaded = false;
         return $this->roles()->detach();
     }
 
@@ -305,11 +307,11 @@ trait HasRoleAndPermission
      * Attach permission to a user.
      *
      * @param int|\Bican\Roles\Models\Permission $permission
-     * @return null|bool
      */
     public function attachPermission($permission)
     {
-        return (!$this->getPermissions()->contains($permission)) ? $this->userPermissions()->attach($permission) : true;
+        $this->permissionsLoaded = false;
+        $this->permissions()->attach($permission);
     }
 
     /**
@@ -320,7 +322,8 @@ trait HasRoleAndPermission
      */
     public function detachPermission($permission)
     {
-        return $this->userPermissions()->detach($permission);
+        $this->permissionsLoaded = false;
+        $this->permissions()->detach($permission);
     }
 
     /**
@@ -330,7 +333,8 @@ trait HasRoleAndPermission
      */
     public function detachAllPermissions()
     {
-        return $this->userPermissions()->detach();
+        $this->permissionsLoaded = false;
+        $this->permissions()->detach();
     }
 
     /**

--- a/src/Bican/Roles/Traits/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Traits/HasRoleAndPermission.php
@@ -129,7 +129,7 @@ trait HasRoleAndPermission
     public function detachRole($role)
     {
         $this->rolesLoaded = false;
-        return $this->roles()->deattach($role);
+        return $this->roles()->detach($role);
     }
 
     /**


### PR DESCRIPTION
It seems that an empty collection gets cached for $this->roles and the check doesn't replace it. Laravel already provides lazy eager loading so I changed the getRoles() and getPermissions() functions to use that.

Here is the unit test that catches it. I suspect that it happens when a role is attached. This pull request makes the unit test pass.

```
<?php

use App\User\Role;
use App\User\Permission;
use App\User\User;
use Illuminate\Foundation\Testing\WithoutMiddleware;
use Illuminate\Foundation\Testing\DatabaseMigrations;
use Illuminate\Foundation\Testing\DatabaseTransactions;

class RoleTest extends TestCase
{
    use DatabaseMigrations;

    public function testAttachRole() {
        $adminRole = $nonAdminUser = factory(Role::class)
            ->create(['slug' => 'admin', 'level' => 1000]);

        $adminUser = factory(User::class)
            ->create(['email' => 'admin@example.com']);
        $adminUser->attachRole($adminRole);

        $this->assertTrue($adminUser->isAdmin());
    }
}
```