### PR TITLE
Artisan console commands

### DIFF
--- a/src/Bican/Roles/Console/AddpermissionCommand.php
+++ b/src/Bican/Roles/Console/AddpermissionCommand.php
@@ -12,7 +12,7 @@ class AddpermissionCommand extends Command
 	 *
 	 * @var string
 	 */
-	protected $signature = 'roles:addpermission {name} {slug?} {description?}';
+	protected $signature = 'roles:addpermission {name} {slug?} {model?} {description?}';
 
 	/**
 	 * The console command description.
@@ -45,6 +45,10 @@ class AddpermissionCommand extends Command
 
 		if($this->argument("description") != "") {
 			$data['description'] = $this->argument("description");
+		}
+
+		if($this->argument("model") != "") {
+			$data['model'] = $this->argument("model");
 		}
 
 		$permissionModel = config('roles.models.permission');

--- a/src/Bican/Roles/Console/AddpermissionCommand.php
+++ b/src/Bican/Roles/Console/AddpermissionCommand.php
@@ -1,0 +1,69 @@
+<?php namespace Bican\Roles\Console;
+
+use Bican\Roles\Models\Permission;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Str;
+
+class AddpermissionCommand extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'roles:addpermission {name} {slug?} {description?}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Add a permission to the database';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function handle()
+	{
+		$data = [
+			'name' => $this->argument("name"),
+			'slug' => Str::slug(($this->argument("slug") ?: strtolower($this->argument("name"))), config('roles.separator')),
+		];
+
+		if($this->argument("description") != "") {
+			$data['description'] = $this->argument("description");
+		}
+
+		$permissionModel = config('roles.models.permission');
+		if($permissionModel::where("name",$data['name'])->orWhere("slug",$data['slug'])->count() > 0) {
+			$this->error("A permission with the same name or slug already exists");
+			return;
+		}
+
+		try {
+			$newModel = $permissionModel::create($data);
+		} catch (QueryException $e) {
+			$this->error("Failed to create the permission: \n".$e->getMessage());
+			return;
+		}
+
+		if(!$newModel instanceof Permission) {
+			$this->error("Failed to create the permission");
+		}
+
+		$this->info("Permission ".$data['name']." created succesfully");
+	}
+}

--- a/src/Bican/Roles/Console/AddroleCommand.php
+++ b/src/Bican/Roles/Console/AddroleCommand.php
@@ -1,0 +1,70 @@
+<?php namespace Bican\Roles\Console;
+
+use Bican\Roles\Models\Role;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Str;
+
+class AddroleCommand extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'roles:addrole {name} {slug?} {level=1} {description?}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Add a role to the database';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function handle()
+	{
+		$data = [
+			'name' => $this->argument("name"),
+			'slug' => Str::slug(($this->argument("slug") ?: strtolower($this->argument("name"))), config('roles.separator')),
+			'level' => (int)$this->argument("level") > 0 ? (int)$this->argument("level") : 1,
+		];
+
+		if($this->argument("description") != "") {
+			$data['description'] = $this->argument("description");
+		}
+
+		$roleModel = config('roles.models.role');
+		if($roleModel::where("name",$data['name'])->orWhere("slug",$data['slug'])->count() > 0) {
+			$this->error("A role with the same name or slug already exists");
+			return;
+		}
+
+		try {
+			$newModel = $roleModel::create($data);
+		} catch (QueryException $e) {
+			$this->error("Failed to create role group: \n".$e->getMessage());
+			return;
+		}
+
+		if(!$newModel instanceof Role) {
+			$this->error("Failed to create role group");
+		}
+
+		$this->info("Role ".$data['name']." created succesfully");
+	}
+}

--- a/src/Bican/Roles/Console/AttachpermissiontoroleCommand.php
+++ b/src/Bican/Roles/Console/AttachpermissiontoroleCommand.php
@@ -1,0 +1,81 @@
+<?php namespace Bican\Roles\Console;
+
+use Bican\Roles\Models\Permission;
+use Illuminate\Console\Command;
+
+class AttachpermissiontoroleCommand extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'roles:attachpermissiontorole {--detach-all} {--detach} {roleIdOrSlug} {permissionIdOrSlug?}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Attach or detach a permission to/from a role';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function handle()
+	{
+		$permissionModel = config('roles.models.permission');
+		$roleModel = config('roles.models.role');
+
+		if((int)$this->argument("roleIdOrSlug") > 0 && (int)$this->argument("roleIdOrSlug") == $this->argument("roleIdOrSlug")) {
+			$role = $roleModel::find((int)$this->argument("roleIdOrSlug"));
+		} elseif($this->argument("roleIdOrSlug") != "") {
+			$role = $roleModel::where("slug",$this->argument("roleIdOrSlug"))->first();
+		} else {
+			$this->error("Invalid or empty role id or slug");
+			return;
+		}
+
+		if($this->option("detach-all")) {
+			$role->detachAllPermissions();
+			$this->info("All roles detached from role '".$role->name."' succesfully");
+			return;
+		}
+
+		if((int)$this->argument("permissionIdOrSlug") > 0 && (int)$this->argument("permissionIdOrSlug") == $this->argument("permissionIdOrSlug")) {
+			$permission = $permissionModel::find((int)$this->argument("permissionIdOrSlug"));
+		} elseif($this->argument("permissionIdOrSlug") != "") {
+			$permission = $permissionModel::where("slug",$this->argument("permissionIdOrSlug"))->first();
+		} else {
+			$this->error("Invalid or empty permission id or slug");
+			return;
+		}
+
+		if(!$permission instanceof Permission) {
+			$this->error("Permission with id or slug specified not found.");
+			return;
+		}
+
+		if($this->option('detach')) {
+			$role->detachPermission($permission);
+
+			$this->info("Permission '".$permission->name."' detached from role '".$role->name."' succesfully");
+		} else {
+			$role->attachPermission($permission);
+
+			$this->info("Permission '".$permission->name."' attacched to role '".$role->name."' succesfully");
+		}
+	}
+}

--- a/src/Bican/Roles/Console/AttachpermissiontouserCommand.php
+++ b/src/Bican/Roles/Console/AttachpermissiontouserCommand.php
@@ -1,0 +1,78 @@
+<?php namespace Bican\Roles\Console;
+
+use Bican\Roles\Models\Permission;
+use Illuminate\Console\Command;
+
+class AttachpermissiontouserCommand extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'roles:attachpermissiontouser {--detach-all} {--detach} {userId} {permissionIdOrSlug?}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Attach or detach a permission to/from a user';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function handle()
+	{
+		$permissionModel = config('roles.models.permission');
+		$userModel = config('auth.model');
+
+		$user = $userModel::find($this->argument("userId"));
+		if(!$user instanceof $userModel) {
+			$this->error("User with id specified not found.");
+			return;
+		}
+
+		if($this->option("detach-all")) {
+			$user->detachAllPermissions();
+			$this->info("All roles detached from user '".$user->name."' succesfully");
+			return;
+		}
+
+		if((int)$this->argument("permissionIdOrSlug") > 0 && (int)$this->argument("permissionIdOrSlug") == $this->argument("permissionIdOrSlug")) {
+			$permission = $permissionModel::find((int)$this->argument("permissionIdOrSlug"));
+		} elseif($this->argument("permissionIdOrSlug") != "") {
+			$permission = $permissionModel::where("slug",$this->argument("permissionIdOrSlug"))->first();
+		} else {
+			$this->error("Invalid or empty permission id or slug");
+			return;
+		}
+
+		if(!$permission instanceof Permission) {
+			$this->error("Permission with id or slug specified not found.");
+			return;
+		}
+
+		if($this->option('detach')) {
+			$user->detachPermission($permission);
+
+			$this->info("Permission '".$permission->name."' detached from user '".$user->name."' succesfully");
+		} else {
+			$user->attachPermission($permission);
+
+			$this->info("Permission '".$permission->name."' attacched to user '".$user->name."' succesfully");
+		}
+	}
+}

--- a/src/Bican/Roles/Console/AttachroletouserCommand.php
+++ b/src/Bican/Roles/Console/AttachroletouserCommand.php
@@ -1,0 +1,78 @@
+<?php namespace Bican\Roles\Console;
+
+use Illuminate\Console\Command;
+use Bican\Roles\Models\Role;
+
+class AttachroletouserCommand extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'roles:attachroletouser {--detach-all} {--detach} {userId} {roleIdOrSlug?}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Attach or detach a role to/from a user';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function handle()
+	{
+		$roleModel = config('roles.models.role');
+		$userModel = config('auth.model');
+
+		$user = $userModel::find($this->argument("userId"));
+		if(!$user instanceof $userModel) {
+			$this->error("User with id specified not found.");
+			return;
+		}
+
+		if($this->option("detach-all")) {
+			$user->detachAllRoles();
+			$this->info("All roles detached from user '".$user->name."' succesfully");
+			return;
+		}
+
+		if((int)$this->argument("roleIdOrSlug") > 0 && (int)$this->argument("roleIdOrSlug") == $this->argument("roleIdOrSlug")) {
+			$role = $roleModel::find((int)$this->argument("roleIdOrSlug"));
+		} elseif($this->argument("roleIdOrSlug") != "") {
+			$role = $roleModel::where("slug",$this->argument("roleIdOrSlug"))->first();
+		} else {
+			$this->error("Invalid or empty role id or slug");
+			return;
+		}
+
+		if(!$role instanceof Role) {
+			$this->error("Role with id or slug specified not found.");
+			return;
+		}
+
+		if($this->option('detach')) {
+			$user->detachRole($role);
+
+			$this->info("Role '".$role->name."' detached from user '".$user->name."' succesfully");
+		} else {
+			$user->attachRole($role);
+
+			$this->info("Role '".$role->name." attacched to user '".$user->name."' succesfully");
+		}
+	}
+}

--- a/src/Bican/Roles/Console/DeletepermissionCommand.php
+++ b/src/Bican/Roles/Console/DeletepermissionCommand.php
@@ -1,0 +1,63 @@
+<?php namespace Bican\Roles\Console;
+
+use Bican\Roles\Models\Permission;
+use Illuminate\Console\Command;
+
+class DeletepermissionCommand extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'roles:deletepermission {--id=} {--slug=}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Delete a permission from the database';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function handle()
+	{
+		$permissionModel = config('roles.models.permission');
+		if((int)$this->option("id") > 0) {
+			$model = $permissionModel::find((int)$this->option("id"));
+		} elseif($this->option("slug") != "") {
+			$model = $permissionModel::where("slug",$this->option("slug"))->first();
+		} else {
+			$this->error("No id or slug option specified. Please use --id= or --slug=");
+			return;
+		}
+
+		if(!$model instanceof Permission) {
+			$this->error("Permission with id or slug specified not found.");
+			return;
+		}
+
+		$name = $model->name;
+
+		if(!$model->delete()) {
+			$this->error("Failed to delete the permission");
+			return;
+		}
+
+		$this->info("Permission '".$name."'' deleted succesfully");
+	}
+}

--- a/src/Bican/Roles/Console/DeleteroleCommand.php
+++ b/src/Bican/Roles/Console/DeleteroleCommand.php
@@ -1,0 +1,63 @@
+<?php namespace Bican\Roles\Console;
+
+use Illuminate\Console\Command;
+use Bican\Roles\Models\Role;
+
+class DeleteroleCommand extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'roles:deleterole {--id=} {--slug=}';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Delete a role from the database';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function handle()
+	{
+		$roleModel = config('roles.models.role');
+		if((int)$this->option("id") > 0) {
+			$model = $roleModel::find((int)$this->option("id"));
+		} elseif($this->option("slug") != "") {
+			$model = $roleModel::where("slug",$this->option("slug"))->first();
+		} else {
+			$this->error("No id or slug option specified. Please use --id= or --slug=");
+			return;
+		}
+
+		if(!$model instanceof Role) {
+			$this->error("Role with id or slug specified not found.");
+			return;
+		}
+
+		$name = $model->name;
+
+		if(!$model->delete()) {
+			$this->error("Failed to delete the role group");
+			return;
+		}
+
+		$this->info("Role '".$name."'' deleted succesfully");
+	}
+}

--- a/src/Bican/Roles/Console/ListpermissionsCommand.php
+++ b/src/Bican/Roles/Console/ListpermissionsCommand.php
@@ -1,0 +1,44 @@
+<?php namespace Bican\Roles\Console;
+
+use Bican\Roles\Models\Permission;
+use Illuminate\Console\Command;
+
+class ListpermissionsCommand extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'roles:listpermissions';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'List the permissions in the database';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function handle()
+	{
+		$headers = ["Id","Name","Slug","Description"];
+		$permissionModel = config('roles.models.permission');
+		$permissions = $permissionModel::all(['id','name','slug','description']);
+		$this->table($headers, $permissions);
+	}
+}

--- a/src/Bican/Roles/Console/ListrolesCommand.php
+++ b/src/Bican/Roles/Console/ListrolesCommand.php
@@ -1,0 +1,44 @@
+<?php namespace Bican\Roles\Console;
+
+use Illuminate\Console\Command;
+use Bican\Roles\Models\Role;
+
+class ListrolesCommand extends Command
+{
+	/**
+	 * The name and signature of the console command.
+	 *
+	 * @var string
+	 */
+	protected $signature = 'roles:listroles';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'List the roles in the database';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return mixed
+	 */
+	public function handle()
+	{
+		$headers = ["Id","Name","Slug","Level","Description"];
+		$roleModel = config('roles.models.role');
+		$roles = $roleModel::all(['id','name','slug','level','description']);
+		$this->table($headers, $roles);
+	}
+}

--- a/src/Bican/Roles/RolesServiceProvider.php
+++ b/src/Bican/Roles/RolesServiceProvider.php
@@ -32,6 +32,18 @@ class RolesServiceProvider extends ServiceProvider
     public function register()
     {
         $this->mergeConfigFrom(__DIR__ . '/../../config/roles.php', 'roles');
+
+        $this->commands('Bican\Roles\Console\ListrolesCommand');
+        $this->commands('Bican\Roles\Console\AddroleCommand');
+        $this->commands('Bican\Roles\Console\DeleteroleCommand');
+
+        $this->commands('Bican\Roles\Console\ListpermissionsCommand');
+        $this->commands('Bican\Roles\Console\AddpermissionCommand');
+        $this->commands('Bican\Roles\Console\DeletepermissionCommand');
+
+        $this->commands('Bican\Roles\Console\AttachroletouserCommand');
+        $this->commands('Bican\Roles\Console\AttachpermissiontouserCommand');
+        $this->commands('Bican\Roles\Console\AttachpermissiontoroleCommand');
     }
 
     /**


### PR DESCRIPTION
I've created some artisan commands that permit to manage the roles and permissions, adding, deleting and attaching/detaching it from the command line.

In my project I don't wont to create an "admin" interface for the permission & role, and I simply wanna insert/delete the entry, without directly inserting it in the database (and doing a minimum data validation)
I've created a command for every basic action in this package, like the creation/elimination of role/permission, or the attach/detach of role/permission from user/role.
This should also be useful for example for api/restful project that doesn't have an admin interface, but wanna use the roles function.