### PR TITLE
Use canOne instead of can so we can resolve the conflicts with authorization 

### DIFF
--- a/src/Bican/Roles/Middleware/VerifyPermission.php
+++ b/src/Bican/Roles/Middleware/VerifyPermission.php
@@ -35,7 +35,7 @@ class VerifyPermission
      */
     public function handle($request, Closure $next, $permission)
     {
-        if ($this->auth->check() && $this->auth->user()->can($permission)) {
+        if ($this->auth->check() && $this->auth->user()->canOne($permission)) {
             return $next($request);
         }
 

--- a/src/Bican/Roles/RolesServiceProvider.php
+++ b/src/Bican/Roles/RolesServiceProvider.php
@@ -52,7 +52,7 @@ class RolesServiceProvider extends ServiceProvider
         });
 
         $blade->directive('permission', function ($expression) {
-            return "<?php if (Auth::check() && Auth::user()->can{$expression}): ?>";
+            return "<?php if (Auth::check() && Auth::user()->canOne{$expression}): ?>";
         });
 
         $blade->directive('endpermission', function () {


### PR DESCRIPTION
Call the 'canOne' function instead of the 'can' function in the Middleware and ServiceProvider so we can make us of Laravel's authorization 'can' function.
Now it's posible to use the Authorizable and the HasRoleAndPermission trait in the user model

``` php
class User extends Model implements AuthenticatableContract, HasRoleAndPermissionContract
{
    use Authenticatable, HasRoleAndPermission, Authorizable {
        Authorizable::can insteadof HasRoleAndPermission;
        HasRoleAndPermission::can as hasRoleAndPermissionCan;
    }
}
```
