### PR TITLE
$model->is('role') not working properly on L5.2

### DIFF
--- a/src/Bican/Roles/Traits/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Traits/HasRoleAndPermission.php
@@ -39,7 +39,7 @@ trait HasRoleAndPermission
      */
     public function getRoles()
     {
-        return (!$this->roles) ? $this->roles = $this->roles()->get() : $this->roles;
+        return (!$this->roles) ? $this->roles = call_user_func([config('roles.models.role'), 'get']) : $this->roles;
     }
 
     /**


### PR DESCRIPTION
Collection of roles not being loaded when `getRoles()` is called.
